### PR TITLE
Remove redundant cache

### DIFF
--- a/sources/DeltaProcessor.swift
+++ b/sources/DeltaProcessor.swift
@@ -55,11 +55,9 @@ public class DeltaProcessor<T: Hashable> {
   private func moved(fromCache: DeltaCache, toCache: DeltaCache) -> [Record] {
     var delta = 0
     var processed: [Int: Int] = Dictionary()
-
-    let _ = self.createIndexCache(self.from)
-    var toIndexCache = self.createIndexCache(self.to)
-
     var records: [Record] = []
+
+    var toIndexCache = self.createIndexCache(self.to)
 
     for (index, item) in self.to.enumerate() {
       while true {


### PR DESCRIPTION
This cache was previously used, but is no longer needed, the variable
was even removed by the Swift 2 converter.
