### PR TITLE
Include files in root folder in podspec

### DIFF
--- a/Delta.podspec.json
+++ b/Delta.podspec.json
@@ -15,7 +15,10 @@
     "ios": "8.0",
     "osx": "10.9"
   },
-  "source_files": "sources/**/*.swift",
+  "source_files": [
+    "sources/**/*.swift",
+    "sources/*.swift"
+  ],
   "osx": {
     "exclude_files": "sources/**/UI*"
   },


### PR DESCRIPTION
For some reason, omitting this makes the pod install seem to miss out on `{delta, cache, processor}.swift` for things like autocomplete, even though it seems to compile & run correctly.
Adding in this lets those files be imported & seen by autocomplete.
