### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Delta
 
 [![Build Status](https://img.shields.io/circleci/project/mogstad/delta.svg?style=flat-square)](https://circleci.com/gh/mogstad/delta)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Delta.svg?style=flat-square)](https://cocoapods.org/pods/Delta)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Delta.svg?style=flat-square)](https://cocoapods.org/pods/Delta)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 
 Handling animations and keeping track of changes manually can be very error-prone,


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
