### PR TITLE
Return correct index paths in update callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 `Delta` adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Return correct `from` index path in update callback.  
+
 ## [3.0.1] - 2016-03-19
 
 ### Added

--- a/sources/data_structures/collection_record.swift
+++ b/sources/data_structures/collection_record.swift
@@ -28,14 +28,25 @@ public enum CollectionRecord: Equatable {
   /// - parameter to: A tuple, with the section and the index of the item, 
   ///   where it’s move to.
   case MoveItem(from: CollectionItem, to: CollectionItem)
-  case ChangeItem(section: Int, index: Int, from: Int)
 
-  /// Section is added
+  /// Describes that an item has been changed. Its identifier is equal, but the 
+  /// model’s equality test fails. Due to internals in Apple’s display classes, 
+  /// it’s required to query for the old cell with the original index path, and
+  /// update it with data from the new index path.
+  ///
+  /// - parameter from: A tuple, with the section and the index of the item
+  ///   where it used to be. Depending on the UI implementation, you might want 
+  ///   to query the cell with these values.
+  /// - parameter to: A tuple, with the section and the index of the item,
+  ///   where it’s ended up being. Use these values to query your data.
+  case ChangeItem(from: CollectionItem, to: CollectionItem)
+
+  /// Describes that a section is to be added.
   /// 
   /// - parameter section: Index of the newly inserted section.
   case AddSection(section: Int)
 
-  /// Describes that a section is moved.
+  /// Describes that a section is to be moved.
   ///
   /// - parameter section: Index of the sections new location.
   /// - parameter from: Index where the section used to be located.
@@ -56,7 +67,13 @@ public enum CollectionRecord: Equatable {
 
 }
 
-/// Equatable conformation, only here to make it easier to test.
+/// Returns whether the two `CollectionRecord` records are equal.
+///
+/// - note: Mostly here to make it easier to write tests.
+///
+/// - parameter lhs: The left-hand side value to compare
+/// - parameter rhs: The Right-hand side value to compare
+/// - returns: Returns `true` iff `lhs` is identical to `rhs`.
 public func ==(lhs: CollectionRecord, rhs: CollectionRecord) -> Bool {
     switch (lhs, rhs) {
     case (let .AddItem(lhsSection, lhsIndex), let .AddItem(rhsSection, rhsIndex)):
@@ -70,8 +87,12 @@ public func ==(lhs: CollectionRecord, rhs: CollectionRecord) -> Bool {
         lhsTo.section == rhsTo.section &&
         lhsTo.index == rhsTo.index)
 
-    case (let .ChangeItem(lhsSection, lhsIndex, lhsFrom), let .ChangeItem(rhsSection, rhsIndex, rhsFrom)):
-      return lhsSection == rhsSection && lhsIndex == rhsIndex && lhsFrom == rhsFrom
+    case (let .ChangeItem(lhsFrom, lhsTo), let .ChangeItem(rhsFrom, rhsTo)):
+      return (
+        lhsFrom.section == rhsFrom.section &&
+        lhsFrom.index == rhsFrom.index &&
+        lhsTo.section == rhsTo.section &&
+        lhsTo.index == rhsTo.index)
 
     case (let .AddSection(lhsIndex), let .AddSection(rhsIndex)):
       return lhsIndex == rhsIndex

--- a/sources/data_structures/delta_change.swift
+++ b/sources/data_structures/delta_change.swift
@@ -17,10 +17,22 @@ public enum DeltaChange: Equatable {
   /// - parameter index: The new index of the item
   /// - parameter from: The old index of the item
   case Move(index: Int, from: Int)
+
+  /// An item has changed. Due to internals in some UI components, we need to 
+  /// know where the item was before the all applied changes.
+  ///
+  /// - parameter index: The index of the item, in the new dataset.
+  /// - parameter from: The index of the item, in the old dataset.
   case Change(index: Int, from: Int)
 }
 
-/// Equatable conformation, only here to make it easier to test.
+/// Returns whether the two `DeltaChange` records are equal.
+///
+/// - note: Mostly here to make it easier to write tests.
+///
+/// - parameter lhs: The left-hand side value to compare
+/// - parameter rhs: The Right-hand side value to compare
+/// - returns: Returns `true` iff `lhs` is identical to `rhs`.
 public func ==(lhs: DeltaChange, rhs: DeltaChange) -> Bool {
   switch (lhs, rhs) {
   case (let .Add(lhsIndex), let .Add(rhsIndex)):
@@ -69,7 +81,9 @@ extension DeltaChange {
         from: (section: oldSection, index: from),
         to: (section: section, index: index))
     case let .Change(index, from):
-      return .ChangeItem(section: section, index: index, from: from)
+      return .ChangeItem(
+        from: (section: oldSection, index: from),
+        to: (section: section, index: index))
     }
   }
 
@@ -77,6 +91,8 @@ extension DeltaChange {
 
 extension DeltaChange: CustomStringConvertible {
 
+  /// The textual representation used when written to an output stream, which 
+  /// includes the name of enum case, and its associated values.
   public var description: String {
     switch self {
     case let .Add(index):

--- a/sources/extensions/UICollectionViewDelta.swift
+++ b/sources/extensions/UICollectionViewDelta.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public extension UICollectionView {
   
-  public typealias CollectionViewUpdateCallback = (NSIndexPath, NSIndexPath) -> Void
+  public typealias CollectionViewUpdateCallback = (from: NSIndexPath, to: NSIndexPath) -> Void
 
   /// Perform updates on the collection view.
   ///
@@ -27,13 +27,13 @@ public extension UICollectionView {
           let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
           let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
           self.moveItemAtIndexPath(fromIndexPath, toIndexPath: indexPath)
-        case let .ChangeItem(section, index, from):
-          let indexPath = NSIndexPath(forRow: index, inSection: section)
+        case let .ChangeItem(from, to):
+          let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
           if let updateCallback = update {
-            let newIndexPath = NSIndexPath(forRow: from, inSection: section)
-            updateCallback(indexPath, newIndexPath)
+            let toIndexPath = NSIndexPath(forRow: to.index, inSection: to.section)
+            updateCallback(from: fromIndexPath, to: toIndexPath)
           } else {
-            self.reloadItemsAtIndexPaths([indexPath])
+            self.reloadItemsAtIndexPaths([fromIndexPath])
           }
         case let .ReloadSection(section):
           self.reloadSections(NSIndexSet(index: section))

--- a/sources/extensions/UITableViewDelta.swift
+++ b/sources/extensions/UITableViewDelta.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public extension UITableView {
 
-  public typealias TableViewUpdateCallback = (NSIndexPath, NSIndexPath) -> Void
+  public typealias TableViewUpdateCallback = (from: NSIndexPath, to: NSIndexPath) -> Void
 
   /// Perform updates on the table view.
   ///
@@ -27,13 +27,13 @@ public extension UITableView {
         let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
         let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
         self.moveRowAtIndexPath(fromIndexPath, toIndexPath: indexPath)
-      case let .ChangeItem(section, index, from):
-        let indexPath = NSIndexPath(forRow: index, inSection: section)
-        let newIndexPath = NSIndexPath(forRow: from, inSection: section)
+      case let .ChangeItem(from, to):
+        let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
+        let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
         if let updateCallback = update {
-          updateCallback(indexPath, newIndexPath)
+          updateCallback(from: fromIndexPath, to: indexPath)
         } else {
-          self.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+          self.reloadRowsAtIndexPaths([fromIndexPath], withRowAnimation: .Automatic)
         }
       case let .ReloadSection(section):
         self.reloadSections(NSIndexSet(index: section), withRowAnimation: .Automatic)

--- a/tests/delta_spec.swift
+++ b/tests/delta_spec.swift
@@ -218,6 +218,41 @@ class SectionedDeltaProcessorSpec: QuickSpec {
           }
         }
 
+        describe("Change records with section changes") {
+          beforeEach {
+            let from = [
+              Section(identifier: 1, items: [
+                Model(identifier: 512, count: 2),
+                ])
+            ]
+
+            let to = [
+              Section(identifier: 0, items: [Model(identifier: 64)]),
+              Section(identifier: 1, items: [
+                Model(identifier: 512, count: 4),
+                ]),
+            ]
+            records = generateRecordsForSections(from: from, to: to)
+          }
+
+          it("generates records") {
+            expect(records.count).to(equal(2))
+          }
+
+          it("adds section") {
+            let record = CollectionRecord.AddSection(section: 0)
+            expect(records[1]).to(equal(record))
+          }
+
+          it("creates change record") {
+            let record = CollectionRecord.ChangeItem(
+              from: (section: 0, index: 0),
+              to: (section: 1, index: 0))
+
+            expect(records[0]).to(equal(record))
+          }
+        }
+
         describe("Moving items and adding section") {
           beforeEach {
             let from = [


### PR DESCRIPTION
Fix implementation flaw in the handling of `ChangeItem`. It used to
assume the section was unchanged, and that is only true there was no
changes in sections before the item. It now returns the true old and new
index paths.
