### PR TITLE
Add preconditions to check for duplicate models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Precondition making sure that multiple objects with the same identifier isn’t
+  passed into delta.
+
 ### Fixed
 
 - Return correct `from` index path in update callback.  

--- a/sources/processor.swift
+++ b/sources/processor.swift
@@ -76,6 +76,8 @@ func changes<Item: DeltaItem where Item: Equatable>(from from: [Item], to: [Item
 
   let fromCache = createItemCache(items: from)
   let toCache = createItemCache(items: to)
+  precondition(fromCache.count == from.count, "Multiple models with the same `deltaIdentifier` found in the passed in sequence `from`")
+  precondition(toCache.count == to.count, "Multiple models with the same `deltaIdentifier` found in the passed in sequence `to`")
 
   return removed(from, toCache: toCache) +
     added(to, fromCache: fromCache) +


### PR DESCRIPTION
Delta assumes there are only one model with the same `deltaIdentifier`
when that assumption is violated, Delta has a tendency to crash. While
it's possible to work around it, it would complicate thing more then
necessary, especially as I consider it incorrect use and should be
treated as a bug from Delta's users.

When Delta crashes it's hard to understand that's the root of the
problem, I therefor added a `precondition` check that will fail if
duplicate models are passed in, giving a clear and concise error
message.
