### PR TITLE
Use old section when creating remove item record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 `Delta` adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unpublished]
+
+### Fixed
+
+- Resolve issue where `RemoveItem` record could use the incorrect section.
+
 ## [4.0.1] - 2016-03-22
 
 ### Fixed

--- a/sources/data_structures/delta_change.swift
+++ b/sources/data_structures/delta_change.swift
@@ -75,7 +75,7 @@ extension DeltaChange {
     case let .Add(index):
       return .AddItem(section: section, index: index)
     case let .Remove(index):
-      return .RemoveItem(section: section, index: index)
+      return .RemoveItem(section: oldSection, index: index)
     case let .Move(index, from):
       return .MoveItem(
         from: (section: oldSection, index: from),

--- a/tests/delta_spec.swift
+++ b/tests/delta_spec.swift
@@ -288,6 +288,72 @@ class SectionedDeltaProcessorSpec: QuickSpec {
           }
         }
 
+        describe("Adding section and removing item") {
+          beforeEach {
+            let from = [
+              Section(identifier: 1, items: [
+                Model(identifier: 512),
+                Model(identifier: 2048)
+              ])
+            ]
+
+            let to = [
+              Section(identifier: 0, items: [Model(identifier: 64)]),
+              Section(identifier: 1, items: [
+                Model(identifier: 512),
+              ]),
+            ]
+            records = generateRecordsForSections(from: from, to: to)
+          }
+
+          it("generates records") {
+            expect(records.count).to(equal(2))
+          }
+
+          it("created add section record") {
+            let record = CollectionRecord.AddSection(section: 0)
+            expect(records[1]).to(equal(record))
+          }
+
+          it("creates remove item record") {
+            let record = CollectionRecord.RemoveItem(section: 0, index: 1)
+            expect(records[0]).to(equal(record))
+          }
+        }
+
+        describe("Removing section and removing item") {
+          beforeEach {
+            let from = [
+              Section(identifier: 0, items: [Model(identifier: 64)]),
+              Section(identifier: 1, items: [
+                Model(identifier: 512),
+                Model(identifier: 2048)
+                ])
+            ]
+
+            let to = [
+              Section(identifier: 1, items: [
+                Model(identifier: 512),
+                ]),
+            ]
+            records = generateRecordsForSections(from: from, to: to)
+          }
+
+          it("generates records") {
+            expect(records.count).to(equal(2))
+          }
+
+          it("created add section record") {
+            let record = CollectionRecord.RemoveSection(section: 0)
+            expect(records[1]).to(equal(record))
+          }
+
+          it("creates remove item record") {
+            let record = CollectionRecord.RemoveItem(section: 1, index: 1)
+            expect(records[0]).to(equal(record))
+          }
+        }
+
         describe("Moving items and adding section") {
           beforeEach {
             let from = [


### PR DESCRIPTION
This shows how desperately we need integration tests for Delta, I'm
confident it now works as expected for UICollectionView, but that might
not be true for other display classes, and I'm not confident it works as
expected on older versions of iOS.
