### PR TITLE
Fix exception when moving & reloading a cell

### DIFF
--- a/sources/extensions/UITableViewDelta.swift
+++ b/sources/extensions/UITableViewDelta.swift
@@ -14,6 +14,8 @@ public extension UITableView {
   ///   to query the cell using the old index path, and update the cell with
   ///   data from the new index path.
   public func performUpdates(records: [CollectionRecord], update: TableViewUpdateCallback? = nil) {
+    var changeRecords: [CollectionRecord] = []
+
     self.beginUpdates()
     for record in records {
       switch record {
@@ -27,14 +29,11 @@ public extension UITableView {
         let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
         let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
         self.moveRowAtIndexPath(fromIndexPath, toIndexPath: indexPath)
-      case let .ChangeItem(from, to):
-        let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
-        let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
-        if let updateCallback = update {
-          updateCallback(from: fromIndexPath, to: indexPath)
-        } else {
-          self.reloadRowsAtIndexPaths([fromIndexPath], withRowAnimation: .Automatic)
-        }
+      case let .ChangeItem(_, _):
+        // A Move & Reload for a single cell cannot occur within the same 
+        // update block (Causes a UIKit exception,) so we queue up the 
+        // reloads to occur after all of the insertions
+        changeRecords.append(record)
       case let .ReloadSection(section):
         self.reloadSections(NSIndexSet(index: section), withRowAnimation: .Automatic)
       case let .MoveSection(section, from):
@@ -46,6 +45,23 @@ public extension UITableView {
       }
     }
     self.endUpdates()
+
+    if changeRecords.count > 0 {
+      self.beginUpdates()
+      for record in changeRecords {
+        guard case let .ChangeItem(from, to) = record else {
+          return fatalError("changeRecords can contain only .ChangeItem, not \(record)")
+        }
+
+        let indexPath = NSIndexPath(forRow: to.index, inSection: to.section)
+        let fromIndexPath = NSIndexPath(forRow: from.index, inSection: from.section)
+        if let updateCallback = update {
+          updateCallback(from: fromIndexPath, to: indexPath)
+        } else {
+          self.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+        }
+      }
+      self.endUpdates()
+    }
   }
-  
 }


### PR DESCRIPTION
UITableView & UICollectionView do not allow moving & reloading a cell in the same batch of updates, doing so will cause an internal inconsistency exception.

To fix this, we queue the rows to be reloaded, and run another update block after all of the insertions / deletions / movements. When doing so, we now need to call reload on the new indexPath, since the item has already been moved.

TODO:
- [ ] Implement similar fix for UICollectionView extension

I'm not certain how to implement the UICollectionView extension fix -- Do we run another `performBatchUpdates` in the completion block of the first? or do we run another immediately after the first call, in the same scope?
