### PR TITLE
Prevent an index out of range issue while generating change set

### DIFF
--- a/sources/processor.swift
+++ b/sources/processor.swift
@@ -51,6 +51,10 @@ func changes<Item: DeltaItem>(from: [Item], to: [Item]) -> [DeltaChange] where I
         }
 
         let compareIndex = index + delta
+        if from.indices.contains(compareIndex) == false {
+          break
+        }
+
         let compareItem = from[compareIndex]
         let compareIdentifer = compareItem.deltaIdentifier
 

--- a/tests/processor_spec.swift
+++ b/tests/processor_spec.swift
@@ -206,6 +206,32 @@ class DeltaProcessorSpec: QuickSpec {
           expect(records[1]).to(equal(record))
         }
       }
+
+      describe("Removing an item while moving another") {
+        beforeEach {
+          let from = [
+            Model(identifier: 0),
+            Model(identifier: 1),
+            Model(identifier: 2),
+          ]
+          let to = [
+            Model(identifier: 2),
+            Model(identifier: 1),
+          ]
+
+          records = self.records(from, to: to)
+          expect(records.count).to(equal(2))
+        }
+
+        it("moves the record") {
+          let removeRecord = DeltaChange.remove(index: 0)
+          expect(records[0]).to(equal(removeRecord))
+
+          let moveRecord = DeltaChange.move(index: 0, from: 2)
+          expect(records[1]).to(equal(moveRecord))
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
The index out of range issue was triggered while removing a row and
moving rows below it, without adding more rows.